### PR TITLE
Add Clojars version and description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+[![Clojars Project](http://clojars.org/thinktopic/raven/latest-version.svg)](http://clojars.org/thinktopic/raven)
+
+# Raven
+
+A tiny Clojurescript notification library based on [Toastr](https://github.com/CodeSeven/toastr).


### PR DESCRIPTION
A Clojars badge always shows the latest version and provides a link to the Clojars page, which has copy-and-paste leiningen and maven dependency string.
