### PR TITLE
Fix React duplicate key warning

### DIFF
--- a/src/cljs/raven/notify.cljs
+++ b/src/cljs/raven/notify.cljs
@@ -50,7 +50,7 @@
   (fn []
     [:div.notify-wrapper
      (for [n @pending-notifications*]
-       ^{:key n}
+       ^{:key (random-uuid)}
        [notification n])]))
 
 


### PR DESCRIPTION
If a notification is rendered more than once simultaneously, React throws a warning like this:

```
react-dom.inc.js:18238 Warning: flattenChildren(...): Encountered two children with the same key, `...`. Child keys must be unique; when two children share a key, only the first child will be used.
```

~Using the index of the item instead of the options map as the key fixes the issue. It should be safe here since a notification component is never re-rendered.~

Further testing demonstrated the statement above false. Using the index as the key caused the notifications to get messed up in situations where multiple different notifications were rendered simultaneously.

Generating a UUID for each notification seems to work better.